### PR TITLE
Tidy up samples.

### DIFF
--- a/Annotations/Annotations/Annotations.cs
+++ b/Annotations/Annotations/Annotations.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * For more detail see the description of the Annotations sample program on our Developer's site, 
  * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-annotations#annotations
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Annotations

--- a/Annotations/InkAnnotations/InkAnnotations.cs
+++ b/Annotations/InkAnnotations/InkAnnotations.cs
@@ -12,10 +12,7 @@ using Datalogics.PDFL;
  * For more detail see the description of the InkAnnotations sample program on our Developer’s site, 
  * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-annotations#inkannotations
  *  
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/InkAnnotations/Properties/AssemblyInfo.cs
+++ b/Annotations/InkAnnotations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("InkAnnotations")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Annotations/LinkAnnotation/LinkAnnotation.cs
+++ b/Annotations/LinkAnnotation/LinkAnnotation.cs
@@ -7,14 +7,8 @@ using Datalogics.PDFL;
  * 
  * This program creates a PDF file with an embedded hyperlink, which takes the reader to the second page of the document.
  * 
- * For more detail see the description of the LinkAnnotation sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-annotations#linkannotation
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace LinkAnnotations

--- a/Annotations/LinkAnnotation/Properties/AssemblyInfo.cs
+++ b/Annotations/LinkAnnotation/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("LinkAnnotation")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010 Datalogics, Inc.")]
+[assembly: AssemblyCopyright("Copyright ©  2008-2023 Datalogics, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
+++ b/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * This program generates a PDF output file with a line shape (an angle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/PolyLineAnnotations/Properties/AssemblyInfo.cs
+++ b/Annotations/PolyLineAnnotations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("PolyLineAnnotations")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Annotations/PolygonAnnotations/PolygonAnnotations.cs
+++ b/Annotations/PolygonAnnotations/PolygonAnnotations.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * This program generates a PDF output file with a polygon shape (a triangle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/PolygonAnnotations/Properties/AssemblyInfo.cs
+++ b/Annotations/PolygonAnnotations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("PolygonAnnotations")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Annotations/README.md
+++ b/Annotations/README.md
@@ -1,14 +1,14 @@
-## ***Annotations***
+## Annotations
 Collects annotations from a PDF page.
 
-## ***InkAnnotations***
+## InkAnnotations
 Creates an ink annotation on a PDF page.
 
-## ***LinkAnnotation***
+## LinkAnnotation
 Creates a link annotation on a PDF page that navigates the user to another PDF page when clicked.
 
-## ***PolyLineAnnotations***
+## PolyLineAnnotations
 Creates a polyline annotation on a PDF page.
 
-## ***PolygonAnnotations***
+## PolygonAnnotations
 Creates a polygon annotation on a PDF page.

--- a/ContentCreation/AddElements/AddElements.cs
+++ b/ContentCreation/AddElements/AddElements.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * The third page features a rectangle and a curved design. Use this sample for ideas on how
  * to draw an image on a PDF page.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/AddElements/Properties/AssemblyInfo.cs
+++ b/ContentCreation/AddElements/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AddElements_dev")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
+++ b/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
@@ -7,9 +7,6 @@ using System;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace AddHeaderFooter

--- a/ContentCreation/Clips/Clips.cs
+++ b/ContentCreation/Clips/Clips.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * This sample demonstrates working with Clip objects. A clipping path is used to edit the borders of a graphics object.
  *
  * 
- * For more detail see the description of the Clips sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/Clips/Properties/AssemblyInfo.cs
+++ b/ContentCreation/Clips/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Clips_dev")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/CreateBookmarks/CreateBookmarks.cs
+++ b/ContentCreation/CreateBookmarks/CreateBookmarks.cs
@@ -14,15 +14,12 @@ using Datalogics.PDFL;
  * For example, you could put bookmarks for each section heading, allowing a reader to
  * click on a hyperlink and move directly to that section from cross reference elsewhere in the document.
  * 
- * Open the Bookmark-out.PDF file in Acrobat and click the Bookmark icon to display the bookmarks that
+ * Open the Bookmark-out.PDF file in a PDF Viewer and click the Bookmark icon to display the bookmarks that
  * the CreateBookmarks program added to the output PDF document. Several of these bookmarks will zoom to
  * parts of the page. The last three, Child1, 2, and 3, are dummy bookmarks that do not respond when you
  * click on them.  They demonstrate how to rearrange existing bookmarks.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/CreateBookmarks/Properties/AssemblyInfo.cs
+++ b/ContentCreation/CreateBookmarks/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CreateBookmarks")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/GradientShade/GradientShade.cs
+++ b/ContentCreation/GradientShade/GradientShade.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * This sample demonstrates changing the shading of an image on a PDF document page. The image gradually
  * changes from black on the left side of the image, to red on the right side.
  * 
- * For more detail see the description of the GradientShade sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace GradientShade

--- a/ContentCreation/GradientShade/Properties/AssemblyInfo.cs
+++ b/ContentCreation/GradientShade/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("GradientShade")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
 /*
  * Demonstrates working with the Calibrated Gray Space (CaLGray), based on the CIE color space.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  * 
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace MakeDocWithCalGrayColorSpace

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithCalGrayColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * Demonstrates working with the Calibrated RGB Color Space, based on the CIE color space.
  * A, B, and C represent red, blue, and green color values.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithCalRGBColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a file containing a DeviceN color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithDeviceNColorSpace

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithDeviceNColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a file containing an ICC-based color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithICCBasedColorSpace

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithICCBasedColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * to reduce the amount of system memory used for processing images when a limited
  * number of colors are needed.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithIndexedColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithIndexedColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
+++ b/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * CIE XYZ color space, but it includes a dimension L, for lightness,
  * along with a and b coordinates, to define the color.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithLabColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithLabColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithLabColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a PDF document that uses a Separation color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithSeparationColorSpace

--- a/ContentCreation/MakeDocWithSeparationColorSpace/Properties/AssemblyInfo.cs
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("MakeDocWithSeparationColorSpace")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/NameTrees/NameTrees.cs
+++ b/ContentCreation/NameTrees/NameTrees.cs
@@ -11,13 +11,7 @@ using Datalogics.PDFL;
  * dictionary, instead of using a code value as a key to identify an object, a name tree
  * uses names as keys to map to data objects. 
  *
- * For more detail see the description of the NameTrees sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/NameTrees/Properties/AssemblyInfo.cs
+++ b/ContentCreation/NameTrees/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("NameTrees")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/NumberTrees/NumberTrees.cs
+++ b/ContentCreation/NumberTrees/NumberTrees.cs
@@ -11,13 +11,7 @@ using Datalogics.PDFL;
  * keys used in a number tree are integers, rather than character strings, and these keys are sorted
  * in ascending numerical order. 
  *
- * For more detail see the description of the NumberTrees sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/NumberTrees/Properties/AssemblyInfo.cs
+++ b/ContentCreation/NumberTrees/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("NumberTrees")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/RemoteGoToActions/Properties/AssemblyInfo.cs
+++ b/ContentCreation/RemoteGoToActions/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("RemoteGoToActions")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("RemoteGoToActions")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
+++ b/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
@@ -11,13 +11,7 @@ using Datalogics.PDFL;
  * RemoteGoToActions differs from LaunchActions in that it includes a RemoteDestination object.
  * This object describes the rectangle used in the PDF file in a series of statements at the command prompt. 
  *
- * For more detail see the description of the AnnotationCopyPaste sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-actions-in-pdf-files#remotegotoactions
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/WriteNChannelTiff/Properties/AssemblyInfo.cs
+++ b/ContentCreation/WriteNChannelTiff/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("WriteNChannelTiff")]
-[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyCopyright("Copyright © 2012-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
+++ b/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
@@ -10,13 +10,7 @@ using Datalogics.PDFL;
  * This sample generates a multi-page TIFF file, selecting graphics drawn from
  * the first page of the PDF document provided.
  * 
- * For more detail see the description of the WriteNChannelTiff sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images#writenchanneltiff
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/Action/Action.cs
+++ b/ContentModification/Action/Action.cs
@@ -8,10 +8,7 @@ using Datalogics.PDFL;
  * An action is added to the rectangle in the form of a hyperlink; if the reader
  * clicks on the rectangle, the system opens a Datalogics web page.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Actions

--- a/ContentModification/AddCollection/AddCollection.cs
+++ b/ContentModification/AddCollection/AddCollection.cs
@@ -9,14 +9,8 @@ using Datalogics.PDFL;
  * 
  * A PDF Portfolio can hold and display multiple additional files as attachments.
  * 
- * For more detail see the description of the AddCollection sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-a-pdf-collection-or-portfolio
- * 
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddCollection

--- a/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
+++ b/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
@@ -12,14 +12,8 @@ using Datalogics.PDFL;
  * The sample changes the states of the layers in the document called Layers.pdf and
  * saves the result to a new PDF document.
  * 
- * For more detail see the description of the ChangeLayerConfiguration sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/layers-and-transparencies/ 
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ChangeLayerConfiguration

--- a/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
+++ b/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
@@ -11,13 +11,7 @@ using Datalogics.PDFL;
  * rectangles, and then finds the text that lines up within these rectangles and changes the
  * color of each character that is a part of the hyperlink.  
  * 
- * For more detail see the description of the ChangeLinkColors sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/working-with-annotations#changelinkcolors
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ChangeLinkColors

--- a/ContentModification/ChangeLinkColors/Properties/AssemblyInfo.cs
+++ b/ContentModification/ChangeLinkColors/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ChangeLinkColors")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/CreateLayer/CreateLayer.cs
+++ b/ContentModification/CreateLayer/CreateLayer.cs
@@ -10,14 +10,9 @@ using Datalogics.PDFL;
  * The related ChangeLayerConfiguration program makes layers visible or invisible.
  * 
  * You can toggle back and forth to make the layer (the duck image) visible or invisible
- * in the PDF file. Open the output PDF document in Adobe Acrobat, click View and select
+ * in the PDF file. Open the output PDF document in a PDF Viewer, click View and select
  * Show/Hide. Select Navigation Panes and Layers to display the layers in the PDF file. 
  * Click on the box next to the name of the layer.
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace CreateLayer
@@ -87,7 +82,7 @@ namespace CreateLayer
             OptionalContentGroup ocg = new OptionalContentGroup(doc, name);
 
             // Add it to the Order array -- this is required so that the OptionalContentGroup
-            // will appear in the 'Layers' control panel in Acrobat.  It will appear in
+            // will appear in the 'Layers' control panel in a PDF Viewer.  It will appear in
             // the control panel with the name given in the OptionalContentGroup constructor.
             OptionalContentOrderArray order_list = doc.DefaultOptionalContentConfig.Order;
             order_list.Insert(order_list.Length, new OptionalContentOrderLeaf(ocg));

--- a/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
+++ b/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
@@ -12,13 +12,7 @@ using Datalogics.PDFL;
  * 
  * This sample program shows how to use the Extended Graphic State object to add graphics parameters to an image.
  * 
- * For more detail see the description of the ExtendedGraphicState sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/adding-text-and-graphic-elements#extendedgraphicstates
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/ExtendedGraphicStates/Properties/AssemblyInfo.cs
+++ b/ContentModification/ExtendedGraphicStates/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ExtendedGraphicStates")]
-[assembly: AssemblyCopyright("Copyright ©  2009-2010")]
+[assembly: AssemblyCopyright("Copyright © 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/FlattenTransparency/FlattenTransparency.cs
+++ b/ContentModification/FlattenTransparency/FlattenTransparency.cs
@@ -13,14 +13,8 @@ using Datalogics.PDFL;
  * appears on the page. The process to flatten a set of transparencies merges them
  * into a single image on the page.
  *
- * For more detail see the description of the FlattenTransparency sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/layers_and_transparencies#flattentransparency 
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/FlattenTransparency/Properties/AssemblyInfo.cs
+++ b/ContentModification/FlattenTransparency/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("FlattenTransparency")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/LaunchActions/LaunchActions.cs
+++ b/ContentModification/LaunchActions/LaunchActions.cs
@@ -8,7 +8,7 @@ using Datalogics.PDFL;
  * An action is added to the rectangle in the form of a hyperlink; if the reader clicks
  * on the rectangle, a different PDF file opens, showing an image.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  * For complete copyright information, refer to:
  * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/

--- a/ContentModification/LaunchActions/Properties/AssemblyInfo.cs
+++ b/ContentModification/LaunchActions/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LaunchActions")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("LaunchActions")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2010-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/MergePDF/MergePDF.cs
+++ b/ContentModification/MergePDF/MergePDF.cs
@@ -8,10 +8,7 @@ using System.Collections.Generic;
  * prompts the user to enter the names of two PDF files, and then inserts the content 
  * of the second PDF file into the first PDF file and saves the result in a third PDF file.
  *
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -41,17 +38,6 @@ namespace MergePDF
 
                 if (args.Length > 2)
                     sOutput = args[2];
-
-                // Issue 1: merge_pdf2.pdf has no attachment or embedded files. Using 
-                // doc1.Attachments results in "The document doesn't contain a EmbeddedFiles dictionary" exception
-                // which then has to be handled.  Shouldn't it just return a 0 length IList?  
-                // Or perhaps DLE should have methods that return the # of attachements 
-                // (e.g. Document.numAttachments and Document.numAnnotationAttachments))
-                // so that the application can check first?
-                
-                // Issue 2: attachments.pdf has contains 2 attachments, one regular, one attached to an annotation.
-                //   Acrobat lists both, but doc1.Attachments only retrieves 1. 
-                // 
 
                 using (Document doc1 = new Document(sInput1))
                 {

--- a/ContentModification/MergePDF/Properties/AssemblyInfo.cs
+++ b/ContentModification/MergePDF/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MergePDF")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/PDFObject/PDFObject.cs
+++ b/ContentModification/PDFObject/PDFObject.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * This sample demonstrates working with data objects in a PDF document. It examines the Objects and displays
  * information about them.  The sample extracts the dictionary for an object called URIAction and updates it using PDFObjects.
  * 
- * For more detail see the description of the PDFObject sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pdfobject
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- * 
  * Suggested input file: Library.ResourceDirectory + "Sample_Input/sample_links.pdf"
  * Input file properties: First page must have an annotation with a URI link
  */

--- a/ContentModification/PDFObject/Properties/AssemblyInfo.cs
+++ b/ContentModification/PDFObject/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PDFObject")]
-[assembly: AssemblyCopyright("Copyright ©  2007-2023")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/PageLabels/PageLabels.cs
+++ b/ContentModification/PageLabels/PageLabels.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * This sample demonstrates working with page labels in a PDF document. Each PDF file has a 
  * data structure that governs how page numbers appear, such as the font and type of numeral.
  *
- * For more detail see the description of the PageLabels sample on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pagelabels
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/PageLabels/Properties/AssemblyInfo.cs
+++ b/ContentModification/PageLabels/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("PageLabels")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2007")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/UnderlinesAndHighlights/Properties/AssemblyInfo.cs
+++ b/ContentModification/UnderlinesAndHighlights/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("UnderlinesAndHighlights")]
-[assembly: AssemblyCopyright("Copyright ©  2010 Datalogics, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2010-2023 Datalogics, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
+++ b/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * a National Weather Service web page, highlighting the word “Cloudy” wherever it appears and underlining
  * the word “Rain.”
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace UnderlinesAndHighlights

--- a/ContentModification/Watermark/Properties/AssemblyInfo.cs
+++ b/ContentModification/Watermark/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Watermark")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ContentModification/Watermark/Watermark.cs
+++ b/ContentModification/Watermark/Watermark.cs
@@ -12,13 +12,7 @@ using Datalogics.PDFL;
  * a set of photographs shown in a PDF file so that they cannot be easily duplicated without
  * the permission of the owner.
  * 
- * For more detail see the description of the Watermark sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/adding-text-and-graphic-elements#watermark
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/DisplayPDF.cs
+++ b/Display/DisplayPDF/DisplayPDF.cs
@@ -5,12 +5,9 @@ using Datalogics.PDFL;
 
 /*
  * This sample shows how to open a PDF document, search for text in the pages and highlight
- * the text using the C# drawing library. DisplayPDF is a simpler version of the DotNETViewer sample.
+ * the text. DisplayPDF is a simpler version of the DotNETViewer sample.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/DisplayPDFForm.Designer.cs
+++ b/Display/DisplayPDF/DisplayPDFForm.Designer.cs
@@ -1,10 +1,6 @@
 /*
-Copyright (c) 2007, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 namespace DisplayPDF

--- a/Display/DisplayPDF/DisplayPDFForm.cs
+++ b/Display/DisplayPDF/DisplayPDFForm.cs
@@ -12,7 +12,7 @@ using Datalogics.PDFL;
  * Sample to demonstrate how to open a PDF document, search for text in
  * the pages and highlight the text using the C# drawing library.
  * 
- * Copyright (c) 2007-2010, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  * The information and code in this sample is for the exclusive use of Datalogics
  * customers and evaluation users only.  Datalogics permits you to use, modify and

--- a/Display/DisplayPDF/MyPictureBox.cs
+++ b/Display/DisplayPDF/MyPictureBox.cs
@@ -9,12 +9,8 @@ using System.Drawing.Drawing2D;
 using Datalogics.PDFL;
 
 /*
-Copyright (c) 2007, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 namespace DisplayPDF

--- a/Display/DisplayPDF/Properties/AssemblyInfo.cs
+++ b/Display/DisplayPDF/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("DisplayPDF")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2007")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Display/DotNETViewer/DotNETViewer.cs
+++ b/Display/DotNETViewer/DotNETViewer.cs
@@ -10,14 +10,9 @@ using System.Drawing;
 /* 
  * This sample is a utility that demonstrates a PDF viewing tool. You can use it to open, display, and edit PDF files.
  * 
- * For more detail see the description of the DotNETViewer on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/viewing-pdf-files
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
 */
 namespace DotNETViewer
 {

--- a/Display/DotNETViewer/Properties/AssemblyInfo.cs
+++ b/Display/DotNETViewer/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNETViewer")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("DotNETViewer")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2010-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Display/DotNETViewerComponent/Annotations/AnnotationStuff.cs
+++ b/Display/DotNETViewerComponent/Annotations/AnnotationStuff.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 using System;

--- a/Display/DotNETViewerComponent/BookmarkManager.cs
+++ b/Display/DotNETViewerComponent/BookmarkManager.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/Classes.cs
+++ b/Display/DotNETViewerComponent/Classes.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/DotNETController.cs
+++ b/Display/DotNETViewerComponent/DotNETController.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/DotNETPrintController.cs
+++ b/Display/DotNETViewerComponent/DotNETPrintController.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/DotNETPrintDialog.cs
+++ b/Display/DotNETViewerComponent/DotNETPrintDialog.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /// <summary>

--- a/Display/DotNETViewerComponent/DotNETView.cs
+++ b/Display/DotNETViewerComponent/DotNETView.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/DotNETViewer.cs
+++ b/Display/DotNETViewerComponent/DotNETViewer.cs
@@ -1,15 +1,13 @@
 /*
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
 */
 
 /*
  * DotNETViewer.cs
  * 
  * DotNETViewer is a User Control that can be added to an existing application from
- * the toolbox in visual studio. It provides a graphical user interface for users
+ * the toolbox in Visual Studio. It provides a graphical user interface for users
  * to view/edit PDFs.
  * 
  *  Featues :

--- a/Display/DotNETViewerComponent/Enums.cs
+++ b/Display/DotNETViewerComponent/Enums.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/ImageArray2DManager.cs
+++ b/Display/DotNETViewerComponent/ImageArray2DManager.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/LayersManager.cs
+++ b/Display/DotNETViewerComponent/LayersManager.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/Properties/AssemblyInfo.cs
+++ b/Display/DotNETViewerComponent/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("DotNETViewerComponent")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2009")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Display/DotNETViewerComponent/TextSearchManager.cs
+++ b/Display/DotNETViewerComponent/TextSearchManager.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/ZoomManager.cs
+++ b/Display/DotNETViewerComponent/ZoomManager.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/frmAnnotationProperties.cs
+++ b/Display/DotNETViewerComponent/frmAnnotationProperties.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/frmColorPicker.cs
+++ b/Display/DotNETViewerComponent/frmColorPicker.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/frmLineWidth.cs
+++ b/Display/DotNETViewerComponent/frmLineWidth.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*

--- a/Display/DotNETViewerComponent/frmMonitorResolution.cs
+++ b/Display/DotNETViewerComponent/frmMonitorResolution.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*  

--- a/Display/DotNETViewerComponent/frmPassword.cs
+++ b/Display/DotNETViewerComponent/frmPassword.cs
@@ -1,11 +1,6 @@
 /*
-Copyright (C) 2008-2009, Datalogics, Inc. All rights reserved.
+Copyright (C) 2008-2023, Datalogics, Inc. All rights reserved.
  
-The information and code in this sample is for the exclusive use
-of Datalogics customers and evaluation users only.  Datalogics 
-permits you to use, modify and distribute this file in accordance 
-with the terms of your license agreement. Sample code is for 
-demonstrative purposes only and is not intended for production use.
 */
 
 /*  

--- a/Display/PDFObjectExplorer/PDFObjectExplorer.cs
+++ b/Display/PDFObjectExplorer/PDFObjectExplorer.cs
@@ -9,13 +9,8 @@ using Datalogics.PDFL;
  * information about objects embedded in a PDF file. These objects include arrays, dictionaries,
  * streams of characters, and integers.
  *
- * For more detail see the description of the PDFObjectExplorer sample on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pdfobjectexplorer
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Display/PDFObjectExplorer/Properties/AssemblyInfo.cs
+++ b/Display/PDFObjectExplorer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("PDF Object Explorer")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Display/PDFObjectExplorer/frmMain.cs
+++ b/Display/PDFObjectExplorer/frmMain.cs
@@ -10,19 +10,14 @@ using Datalogics.PDFL;
 using System.Text;
 
 /*
- * Copyright (c) 2007-2013, Datalogics, Inc. All rights reserved.
- *
- * The information and code in this sample is for the exclusive use of Datalogics
- * customers and evaluation users only.  Datalogics permits you to use, modify and
- * distribute this file in accordance with the terms of your license agreement.
- * Sample code is for demonstrative purposes only and is not intended for production use.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved..
  *
  * ============================ PDF OBJECT EXPLORER ===================================
  * Demonstrates a GUI-based browser for PDF objects, letting the user examine a PDF at
  * the level of dictionaries, streams, and simple datatypes like strings and integers.
  * This sample serves two purposes:
  *
- * 1) It demonstrates how to use the PDFObject API in DLE, including features like
+ * 1) It demonstrates how to use the PDFObject API, including
  *    the PDFObjectEnumProc callback
  *
  * 2) It can also be built and run 'out of the box' as a tool for inspecting PDF

--- a/Display/PDFObjectExplorer/frmPassword.cs
+++ b/Display/PDFObjectExplorer/frmPassword.cs
@@ -2,12 +2,7 @@ using System;
 using System.Windows.Forms;
 
 /*
- * Copyright (c) 2007-2013, Datalogics, Inc. All rights reserved.
- *
- * The information and code in this sample is for the exclusive use of Datalogics
- * customers and evaluation users only.  Datalogics permits you to use, modify and
- * distribute this file in accordance with the terms of your license agreement.
- * Sample code is for demonstrative purposes only and is not intended for production use.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  * Demonstrates a GUI-based browser for PDF objects.  This dialog prompts for passwords.
  */

--- a/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
+++ b/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
@@ -13,13 +13,7 @@ using Datalogics.PDFL;
  * Note that the color profile is not embedded by default; rather, the default is not to embed the color profile.
  * The user must set the option to embed to True.
  * 
- * For more detail see the description of the ColorConvertDocument sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/color-conversion
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ColorConvertDocument

--- a/DocumentConversion/ConvertToOffice/ConvertToOffice.cs
+++ b/DocumentConversion/ConvertToOffice/ConvertToOffice.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
  * 
  * ConvertToOffice converts sample PDF documents to Office Documents.
  *
- * For more detail see the description of the ConvertToOffice sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content
- * 
  * Copyright (c) 2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace ConvertToOffice

--- a/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
+++ b/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
@@ -9,10 +9,8 @@ using Datalogics.PDFL;
  * XML Paper Specification (XPS) is a standard document format that Microsoft created in 2006
  * as an alternative to the PDF format.  
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/DocumentConversion/CreateDocFromXPS/Properties/AssemblyInfo.cs
+++ b/DocumentConversion/CreateDocFromXPS/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("CreateDocFromXPS")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
+++ b/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
@@ -5,13 +5,8 @@ using Datalogics.PDFL;
  * 
  * This sample demonstrates converting the input PDF with the input Invoice XML to a Factur-X compliant PDF.
  *
- * For more detail see the description of the Factur-XConverter sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content/#facturxconverter
- * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace FacturXConverter

--- a/DocumentConversion/PDFAConverter/PDFAConverter.cs
+++ b/DocumentConversion/PDFAConverter/PDFAConverter.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * This sample demonstrates converting a standard PDF document into a
  * PDF Archive, or PDF/A, compliant version of a PDF file.
  *
- * For more detail see the description of the PDFAConverter sample program on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-and-merging-pdf-content
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFAConverter

--- a/DocumentConversion/PDFXConverter/PDFXConverter.cs
+++ b/DocumentConversion/PDFXConverter/PDFXConverter.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * 
  * The sample takes a default input and output a document (both optional). 
  * 
- * For more detail see the description of the PDFXConverter sample program on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-and-merging-pdf-content#pdfxconverter
- *
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFXConverter

--- a/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
+++ b/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * 
  * This sample demonstrates converting the input PDF with the input Invoice ZUGFeRD XML to a ZUGFeRD compliant PDF.
  *
- * For more detail see the description of the ZUGFeRDConverter sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-and-merging-pdf-content/#zugferdconverter
- * 
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ZUGFeRDConverter

--- a/DocumentOptimization/PDFOptimize/PDFOptimize.cs
+++ b/DocumentOptimization/PDFOptimize/PDFOptimize.cs
@@ -11,14 +11,8 @@ using System;
  * to suit your applications needs and drop such content to achieve better compression if you already
  * know it's unnecessary.
  * 
- * For more detail see the description of the PDFOptimizer sample program on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/using-the-pdf-optimizer-to-manage-the-size-of-pdf-documents
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFOptimize

--- a/DocumentOptimization/PDFOptimize/Properties/AssemblyInfo.cs
+++ b/DocumentOptimization/PDFOptimize/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PDFOptimize")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2023")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/DocToImages/DocToImages.cs
+++ b/Images/DocToImages/DocToImages.cs
@@ -9,14 +9,7 @@ using Datalogics.PDFL;
  * one per page. You can also create a mult-page TIFF file. This program requires that you enter 
  * formatting values manually at the command line. 
  *
- * For more detail, and information about the command line parameters, see the description of the DocToImages
- * sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-pdf-pages-to-images/#doctoimages
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/DocToImages/Properties/AssemblyInfo.cs
+++ b/Images/DocToImages/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DocToImages")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright ©  2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/DrawSeparations/DrawSeparations.cs
+++ b/Images/DrawSeparations/DrawSeparations.cs
@@ -10,13 +10,7 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates for drawing a list of grayscale separations from a PDF file.
  *
- * For more detail see the description of the DrawSeparations sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/DrawSeparations/Properties/AssemblyInfo.cs
+++ b/Images/DrawSeparations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DrawSeparations")]
-[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyCopyright("Copyright © 2012-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/Images/DrawToBitmap/DrawToBitmap.cs
@@ -12,14 +12,8 @@ using Datalogics.PDFL;
  *
  * This program sample converts a PDF file to a series of bitmap image files.
  * 
- * For more detail see the description of the DrawtoBitmap sample program on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-pdf-pages-to-images/#drawtobitmap
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/DrawToBitmap/Properties/AssemblyInfo.cs
+++ b/Images/DrawToBitmap/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DrawToBitmap")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/EPSSeparations/EPSSeparations.cs
+++ b/Images/EPSSeparations/EPSSeparations.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * This sample demonstrates working with color separations with Encapsulated PostScript (EPS) graphics
  * from a PDF file.
  *
- * For more detail see the description of the EPSSeparations sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images#epsseparations
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Actions

--- a/Images/EPSSeparations/Properties/AssemblyInfo.cs
+++ b/Images/EPSSeparations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("EPSSeparations")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -10,14 +10,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
- * For more detail see the description of the GetSeparatedImages sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/manipulating-graphics-and-separating-colors-for-images#getseparatedimages
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/GetSeparatedImages/Properties/AssemblyInfo.cs
+++ b/Images/GetSeparatedImages/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("GetSeparatedImages")]
-[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyCopyright("Copyright © 2012-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
+++ b/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
@@ -13,13 +13,7 @@ using Datalogics.PDFL;
  * The program sets up how the output will be rendered and generates a TIF image file or
  * series of TIF files as output.
  * 
- * For more detail see the description of the ImageEmbedICCProfile sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/exporting-images-from-pdf-files/#imageembediccprofile
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ImageEmbedICCProfile

--- a/Images/ImageEmbedICCProfile/Properties/AssemblyInfo.cs
+++ b/Images/ImageEmbedICCProfile/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("ImageEmbedICCProfile")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("ImageEmbedICCProfile")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2011")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2011-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageExport/ImageExport.cs
+++ b/Images/ImageExport/ImageExport.cs
@@ -14,13 +14,7 @@ using Datalogics.PDFL;
  * sets of graphics files for those three images. The sample program ignores text, parsing the
  * PDF syntax to identify any raster or vector images found on every page.
  *
- * For more detail see the description of the ImageExport sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/exporting-images-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExport/Properties/AssemblyInfo.cs
+++ b/Images/ImageExport/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ImageExport")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright ©  2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageExtraction/ImageExtraction.cs
+++ b/Images/ImageExtraction/ImageExtraction.cs
@@ -13,14 +13,8 @@ using Datalogics.PDFL;
  * images from the PDF file and copies them to a separate set of graphics files in the
  * same directory. Vector images, such as clip art, will not be exported.
  * 
- * For more detail see the description of the ImageExtraction sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/exporting-images-from-pdf-files/#imageextraction
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageExtraction/Properties/AssemblyInfo.cs
+++ b/Images/ImageExtraction/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ImageExtraction")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright ©  2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageFromStream/ImageFromStream.cs
+++ b/Images/ImageFromStream/ImageFromStream.cs
@@ -12,15 +12,8 @@ using Datalogics.PDFL;
  * that is used to interpret the values in the stream.
  * 
  * This program is similar to StreamIO.
- *
- * For more detail see the description of the ImagefromStream sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/exporting-images-from-pdf-files/#imagefromstream
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ImageFromStream

--- a/Images/ImageFromStream/Properties/AssemblyInfo.cs
+++ b/Images/ImageFromStream/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ImageFromStream")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageImport/ImageImport.cs
+++ b/Images/ImageImport/ImageImport.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * prompting you, and creates two PDF files, demonstrating how to import graphics from image files
  * into a PDF file. One of the PDF output files is the result of graphics imported from a multi-page TIF file.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageImport/Properties/AssemblyInfo.cs
+++ b/Images/ImageImport/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ImageImport")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageResampling/ImageResampling.cs
+++ b/Images/ImageResampling/ImageResampling.cs
@@ -15,13 +15,7 @@ using Datalogics.PDFL;
  * used to reduce the resolution of an image or series of images, to make them smaller. As a result
  * the process makes the PDF document smaller.
  *
- * For more detail see the description of the ImageResampling sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageResampling/Properties/AssemblyInfo.cs
+++ b/Images/ImageResampling/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ImageResampling")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/ImageSoftMask/ImageSoftMask.cs
+++ b/Images/ImageSoftMask/ImageSoftMask.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * change a feature, while a soft mask allows you to place an image on a page and define the level of 
  * transparency for that image.
  *
- * For more detail see the description of the ImageSoftMask sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageSoftMask/Properties/AssemblyInfo.cs
+++ b/Images/ImageSoftMask/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ImageSoftMask")]
-[assembly: AssemblyCopyright("Copyright ©  2009-2010")]
+[assembly: AssemblyCopyright("Copyright © 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/RasterizePage/Properties/AssemblyInfo.cs
+++ b/Images/RasterizePage/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("RasterizePage")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2023")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Images/RasterizePage/RasterizePage.cs
+++ b/Images/RasterizePage/RasterizePage.cs
@@ -25,10 +25,7 @@ using Datalogics.PDFL;
  * 3. An output image file with content drawn from an unrotated PDF page, but that contains only the top half of
  *    the original page.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace RasterizePage

--- a/InformationExtraction/ListBookmarks/ListBookmarks.cs
+++ b/InformationExtraction/ListBookmarks/ListBookmarks.cs
@@ -7,14 +7,8 @@ using Datalogics.PDFL;
  * 
  * This sample finds and describes the bookmarks included in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListBookmarks, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
  * 
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListBookmarks/Properties/AssemblyInfo.cs
+++ b/InformationExtraction/ListBookmarks/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ListBookmarks")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/InformationExtraction/ListInfo/ListInfo.cs
+++ b/InformationExtraction/ListInfo/ListInfo.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * This sample shows how to list metadata about a PDF document, and presents command prompts
  * if you want to change these values, such as the title or author. The results are exported
  * to a PDF output document.
- * 
- * For more detail see the description of the List sample programs, and ListInfo, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListInfo/Properties/AssemblyInfo.cs
+++ b/InformationExtraction/ListInfo/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ListInfo")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-203")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/InformationExtraction/ListLayers/ListLayers.cs
+++ b/InformationExtraction/ListLayers/ListLayers.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
 /*
  * This sample searches for and lists the names of the color layers found in a PDF document. 
  *  
- * For more detail see the description of the List sample programs, and ListLayers, on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListLayers/Properties/AssemblyInfo.cs
+++ b/InformationExtraction/ListLayers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ListLayers")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/InformationExtraction/ListPaths/ListPaths.cs
+++ b/InformationExtraction/ListPaths/ListPaths.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * This sample searches for and lists the contents of paths found in an existing PDF document.
  * Paths in PDF documents, or clipping paths, define the boundaries for art or graphics.
  * 
- * For more detail see the description of the List sample programs, and ListPaths, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListPaths/Properties/AssemblyInfo.cs
+++ b/InformationExtraction/ListPaths/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ListPaths")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2011")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2011-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/InformationExtraction/Metadata/Metadata.cs
+++ b/InformationExtraction/Metadata/Metadata.cs
@@ -7,15 +7,9 @@ using System.Xml;
 /*
  *
  * This sample shows how to view and edit metadata for a PDF document. The metadata values appear on the Properties
- * window in Adobe Reader and Adobe Acrobat. Click File/Properties, and then click Additional Metadata.
+ * window in a PDF Viewer. Click File/Properties, and then click Additional Metadata.
  *
- * For more detail see the description of the Metadata sample on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files#metadata
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/Metadata/Properties/AssemblyInfo.cs
+++ b/InformationExtraction/Metadata/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Incorporated")]
 [assembly: AssemblyProduct("Metadata")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2009-2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Incorporated 2009-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
+++ b/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * Process a document using the optical recognition engine.
  * Then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToDocument on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToDocument/Properties/AssemblyInfo.cs
+++ b/OpticalCharacterRecognition/AddTextToDocument/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("AddTextToDocument")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2019")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2019-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
+++ b/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * The sample uses an image as input which will be processed by the optical recognition engine.
  * We will then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToImage, on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2019, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToImage/Properties/AssemblyInfo.cs
+++ b/OpticalCharacterRecognition/AddTextToImage/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("AddTextToImage")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2019")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2019-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Other/MemoryFileSystem/MemoryFileSystem.cs
+++ b/Other/MemoryFileSystem/MemoryFileSystem.cs
@@ -12,10 +12,7 @@ using Datalogics.PDFL;
  * TempStoreType.Memory. The program can also set a maximum amount of RAM to use by
  * applying a value to the DefaultTempStoreMemLimit property.
  *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MemoryFileSystem

--- a/Other/StreamIO/Properties/AssemblyInfo.cs
+++ b/Other/StreamIO/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("StreamIO")]
-[assembly: AssemblyCopyright("Copyright ©  2008-2010")]
+[assembly: AssemblyCopyright("Copyright © 2008-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Other/StreamIO/StreamIO.cs
+++ b/Other/StreamIO/StreamIO.cs
@@ -15,13 +15,7 @@ using Datalogics.PDFL;
  * 
  * This program is similar to ImagefromStream, but in this example the PDF file streams hold text.
  *
- * For more detail see the description of the StreamIO sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/exporting-images-from-pdf-files/#streamio
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace StreamIO

--- a/Other/WebApplication/WebApplication/Default.aspx.cs
+++ b/Other/WebApplication/WebApplication/Default.aspx.cs
@@ -14,11 +14,8 @@ using Datalogics.PDFL;
 
 /*
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- * 
  */
 
 namespace WebApplication

--- a/Other/WebApplication/WebApplication/Properties/AssemblyInfo.cs
+++ b/Other/WebApplication/WebApplication/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("WebApplication")]
-[assembly: AssemblyCopyright("Copyright © 2012 Datalogics, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2012-2023 Datalogics, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Printing/PrintPDF/PrintPDF.cs
+++ b/Printing/PrintPDF/PrintPDF.cs
@@ -15,10 +15,7 @@ using Datalogics.PDFL;
  * runs and automatically generates a PDF output file from the PS file.  This file will match the PDF
  * file you entered to print.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDF/Properties/AssemblyInfo.cs
+++ b/Printing/PrintPDF/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PrintPDF")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Printing/PrintPDFGUI/PrintPDFForm.Designer.cs
+++ b/Printing/PrintPDFGUI/PrintPDFForm.Designer.cs
@@ -3,12 +3,8 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 
 /*
-Copyright (c) 2007, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 namespace PrintPDFGUI

--- a/Printing/PrintPDFGUI/PrintPDFForm.cs
+++ b/Printing/PrintPDFGUI/PrintPDFForm.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
  *
- * For more detail see the description of the PrintPDFGUI sample program on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf
- *
- * Copyright (c) 2007-2018, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDFGUI/PrintPDFGUI.cs
+++ b/Printing/PrintPDFGUI/PrintPDFGUI.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * This sample printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
  * 
- * For more detail see the description of the PrintPDFGUI sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf
- * 
- * Copyright (c) 2007-2018, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDFGUI/Properties/AssemblyInfo.cs
+++ b/Printing/PrintPDFGUI/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics")]
 [assembly: AssemblyProduct("PrintPDFGUI")]
-[assembly: AssemblyCopyright("Copyright © Datalogics 2007")]
+[assembly: AssemblyCopyright("Copyright © Datalogics 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Security/AddRegexRedaction/AddRegexRedaction.cs
+++ b/Security/AddRegexRedaction/AddRegexRedaction.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * document that matches a user-supplied regular expression. When the sample finds the text it
  * will redact the phrase from the output document.
  * 
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddRegexRedaction

--- a/Security/Redactions/Properties/AssemblyInfo.cs
+++ b/Security/Redactions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Redactions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2015-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Security/Redactions/Redactions.cs
+++ b/Security/Redactions/Redactions.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * This sample shows how to redact a PDF document. The program opens an input PDF, searches for
  * specific words using the Adobe PDF Library WordFinder, and then removes these words from the text.
  * 
- * For more detail see the description of the Redactions sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/redacting-text-from-a-pdf-document
- *
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-203, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Redactions

--- a/Text/AddGlyphs/AddGlyphs.cs
+++ b/Text/AddGlyphs/AddGlyphs.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * Use this program to create a new PDF file and add glyphs to the page,
  * managing them by individual Glyph ID codes.
  * 
- * For more detail see the description of the AddGlyphs sample program see
- * https://github.com/datalogics/adobe-pdf-library-samples/tree/master/DotNETFramework/Sample_Source/Text#addglyphs
- * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddGlyphs

--- a/Text/AddUnicodeText/AddUnicodeText.cs
+++ b/Text/AddUnicodeText/AddUnicodeText.cs
@@ -7,14 +7,8 @@ using Datalogics.PDFL;
  * 
  * This sample program adds six lines of Unicode text to a PDF file, in six different languages.
  *
- * For more detail see the description of the AddUnicodeText sample program on our github site,
- * https://github.com/datalogics/adobe-pdf-library-samples/tree/master/DotNETFramework/Sample_Source/Text#addunicodetext
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace AddUnicodeText

--- a/Text/AddVerticalText/AddVerticalText.cs
+++ b/Text/AddVerticalText/AddVerticalText.cs
@@ -11,10 +11,7 @@ using Datalogics.PDFL;
  * The sample offers several rows of Unicode characters. The sample PDF file thus presents multiple columns
  * of vertical text.  The characters appear in English as well as Mandarin, Japanese, and Korean.
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
+++ b/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
@@ -9,9 +9,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractAcroFormFieldData
 {

--- a/Text/ExtractAcroFormFieldData/Properties/AssemblyInfo.cs
+++ b/Text/ExtractAcroFormFieldData/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ExtractAcroFormFieldData")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright © 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
+++ b/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
@@ -8,9 +8,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractCJKTextByPatternMatch
 {

--- a/Text/ExtractCJKTextByPatternMatch/Properties/AssemblyInfo.cs
+++ b/Text/ExtractCJKTextByPatternMatch/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ExtractCJKTextByPatternMatch")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2023")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
+++ b/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
@@ -8,9 +8,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextByPatternMatch
 {

--- a/Text/ExtractTextByPatternMatch/Properties/AssemblyInfo.cs
+++ b/Text/ExtractTextByPatternMatch/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ExtractTextByPatternMatch")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2023")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractTextByRegion/ExtractTextByRegion.cs
+++ b/Text/ExtractTextByRegion/ExtractTextByRegion.cs
@@ -9,9 +9,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextByRegion
 {

--- a/Text/ExtractTextByRegion/Properties/AssemblyInfo.cs
+++ b/Text/ExtractTextByRegion/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ExtractTextByRegion")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2023")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
+++ b/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
@@ -11,9 +11,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
- *
  */
 namespace ExtractTextFromAnnotations
 {

--- a/Text/ExtractTextFromAnnotations/Properties/AssemblyInfo.cs
+++ b/Text/ExtractTextFromAnnotations/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ExtractTextFromAnnotations")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright © 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
+++ b/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
@@ -10,9 +10,6 @@ using ExtractTextNameSpace;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextFromMultiRegions
 {

--- a/Text/ExtractTextFromMultiRegions/Properties/AssemblyInfo.cs
+++ b/Text/ExtractTextFromMultiRegions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ExtractTextFromMultiRegions")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2023")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
@@ -13,9 +13,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
- *
  */
 namespace ExtractTextPreservingStyleAndPositionInfo
 {

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/Properties/AssemblyInfo.cs
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("ExtractTextPreservingStyleAndPositionInfo")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2023")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2022-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/ListWords/ListWords.cs
+++ b/Text/ListWords/ListWords.cs
@@ -12,7 +12,7 @@ using Datalogics.PDFL;
  * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
  * 
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  * For complete copyright information, refer to:
  * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/

--- a/Text/ListWords/ListWords.cs
+++ b/Text/ListWords/ListWords.cs
@@ -8,14 +8,8 @@ using Datalogics.PDFL;
  * 
  * This sample lists the text for the words in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListWords, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace ListWords

--- a/Text/ListWords/Properties/AssemblyInfo.cs
+++ b/Text/ListWords/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ListWords")]
-[assembly: AssemblyCopyright("Copyright ©  2007")]
+[assembly: AssemblyCopyright("Copyright © 2007-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/RegexExtractText/Properties/AssemblyInfo.cs
+++ b/Text/RegexExtractText/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("RegexExtractText")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2021")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2021-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/RegexExtractText/RegexExtractText.cs
+++ b/Text/RegexExtractText/RegexExtractText.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * that matches a user-supplied regular expression. The output is a JSON file that
  * has the match information.
  * 
- * Copyright (c) 2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexTextSearch/Properties/AssemblyInfo.cs
+++ b/Text/RegexTextSearch/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("RegexTextSearch")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2021")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2021-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/RegexTextSearch/RegexTextSearch.cs
+++ b/Text/RegexTextSearch/RegexTextSearch.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * document that match a user-supplied regular expression. When the sample finds the text it
  * highlights each match and saves the file as an output document.
  * 
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace RegexTextSearch

--- a/Text/TextExtract/Properties/AssemblyInfo.cs
+++ b/Text/TextExtract/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Datalogics, Inc.")]
 [assembly: AssemblyProduct("TextExtract")]
-[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2010")]
+[assembly: AssemblyCopyright("Copyright © Datalogics, Inc. 2010-2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Text/TextExtract/TextExtract.cs
+++ b/Text/TextExtract/TextExtract.cs
@@ -13,10 +13,7 @@ using Datalogics.PDFL;
  * PDF file is tagged or untagged. Tagging is used to make PDF files accessible
  * to the blind or to people with vision problems. 
  * 
- * Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-203, Datalogics, Inc. All rights reserved.
  *
  */
 namespace TextExtract

--- a/_Common/ExtractText.cs
+++ b/_Common/ExtractText.cs
@@ -14,9 +14,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 // This Datalogics sample uses the Newtonsoft.Json library to generate JSON output.


### PR DESCRIPTION
Remove devsite links, all the information is now in this github repository for the samples.

Remove extra DL copyright devsite link which was uncessary.

Update through copyright of all samples.

Some recently created samples needed a through copyright, not just the current year.

Remove asterisks from markdown which had no effect.