### PR TITLE
Add OutputPreview sample.

### DIFF
--- a/Images/OutputPreview/OutputPreview.cs
+++ b/Images/OutputPreview/OutputPreview.cs
@@ -14,6 +14,20 @@ namespace OutputPreview
 {
     class OutputPreview
     {
+        static string CreateOutputFileName(List<string> colorants)
+        {
+            string outputFileName = "OutputPreview_";
+
+            foreach(string colorant in colorants)
+            {
+                outputFileName += colorant + "_";
+            }
+
+            outputFileName += ".tiff";
+
+            return outputFileName;
+        }
+
         static void Main(string[] args)
         {
             Console.WriteLine("OutputPreview Sample:");
@@ -69,11 +83,11 @@ namespace OutputPreview
                         // Create Output Preview images using the Specified Colorants
                         Datalogics.PDFL.Image image = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants);
 
-                        image.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse[0], colorantsToUse[1]), ImageType.TIFF);
+                        image.Save(CreateOutputFileName(colorantsToUse), ImageType.TIFF);
 
                         Datalogics.PDFL.Image image2 = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants2);
 
-                        image2.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse2[0], colorantsToUse2[1]), ImageType.TIFF);
+                        image2.Save(CreateOutputFileName(colorantsToUse2), ImageType.TIFF);
                     }
                 }
             }

--- a/Images/OutputPreview/OutputPreview.cs
+++ b/Images/OutputPreview/OutputPreview.cs
@@ -1,0 +1,82 @@
+using Datalogics.PDFL;
+using System;
+using System.Collections.Generic;
+
+/*
+ * This sample demonstrates creating an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
+ *
+ * 
+ * Copyright (c)2023, Datalogics, Inc. All rights reserved.
+ *
+ */
+
+namespace OutputPreview
+{
+    class OutputPreview
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("OutputPreview Sample:");
+
+            String sInput = Library.ResourceDirectory + "Sample_Input/spotcolors1.pdf";
+
+            // Here you specify the Colorant names of interest
+            List<String> colorantsToUse = new List<string>() { "Yellow", "Black" };
+
+            List<String> colorantsToUse2 = new List<string>() { "PANTONE 554 CVC", "PANTONE 814 2X CVC", "PANTONE 185 2X CVC" };
+
+            using (Library lib = new Library())
+            {
+                using (Document doc = new Document(sInput))
+                {
+                    using (Page pg = doc.GetPage(0))
+                    {
+                        // Get all inks that are present on the page
+                        List<Ink> inks = (List<Ink>)pg.ListInks();
+
+                        List<SeparationColorSpace> colorants = new List<SeparationColorSpace>();
+
+                        foreach (Ink theInk in inks)
+                        {
+                            foreach (String theColorant in colorantsToUse)
+                            {
+                                if (theInk.ColorantName == theColorant)
+                                {
+                                    colorants.Add(new SeparationColorSpace(pg, theInk));
+                                }
+                            }
+                        }
+
+                        List<SeparationColorSpace> colorants2 = new List<SeparationColorSpace>();
+
+                        foreach (Ink theInk in inks)
+                        {
+                            foreach (String theColorant in colorantsToUse2)
+                            {
+                                if (theInk.ColorantName == theColorant)
+                                {
+                                    colorants2.Add(new SeparationColorSpace(pg, theInk));
+                                }
+                            }
+                        }
+
+                        PageImageParams pip = new PageImageParams();
+                        pip.HorizontalResolution = 300;
+                        pip.VerticalResolution = 300;
+
+                        ImageSaveParams sp = new ImageSaveParams();
+
+                        // Create Output Preview images using the Specified Colorants
+                        Datalogics.PDFL.Image image = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants);
+
+                        image.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse[0], colorantsToUse[1]), ImageType.TIFF);
+
+                        Datalogics.PDFL.Image image2 = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants2);
+
+                        image2.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse2[0], colorantsToUse2[1]), ImageType.TIFF);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Images/OutputPreview/OutputPreview.csproj
+++ b/Images/OutputPreview/OutputPreview.csproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{16ABC796-99B8-AEC6-947E-3355E8E6B090}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OutputPreview</RootNamespace>
+    <AssemblyName>OutputPreview</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>2.0</OldToolsVersion>
+    <UpgradeBackupLocation />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\Binaries</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\Binaries</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\Binaries</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\Binaries</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Datalogics.PDFL">
+      <HintPath>..\..\..\Binaries\Datalogics.PDFL.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OutputPreview.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Images/OutputPreview/OutputPreview.sln
+++ b/Images/OutputPreview/OutputPreview.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33328.57
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutputPreview", "OutputPreview.csproj", "{16ABC796-99B8-AEC6-947E-3355E8E6B090}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Debug|x64.ActiveCfg = Debug|x64
+		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Debug|x64.Build.0 = Debug|x64
+		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Release|x64.ActiveCfg = Release|x64
+		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Images/OutputPreview/Properties/AssemblyInfo.cs
+++ b/Images/OutputPreview/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OutputPreview")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OutputPreview")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("16ABC796-99B8-AEC6-947E-3355E8E6B090")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Images/README.md
+++ b/Images/README.md
@@ -34,5 +34,8 @@ Explores the content of PDF pages and when images are found they are resampled t
 ## ***ImageSoftMask***
 Adds an image file to be placed on a PDF page and adds another image file to use as its SoftMask image.
 
+## ***OutputPreview***
+Creates an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
+
 ## ***RasterizePage***
 Rasterizes the first page of a PDF document.

--- a/Samples.sln
+++ b/Samples.sln
@@ -88,6 +88,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EPSSeparations", "Images\EP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetSeparatedImages", "Images\GetSeparatedImages\GetSeparatedImages.csproj", "{16ABC796-99B8-AEC6-947E-3355E8E6B090}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutputPreview", "Images\OutputPreview\OutputPreview.csproj", "{7B383C18-C183-4549-A5BF-CC488A08DF52}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageEmbedICCProfile", "Images\ImageEmbedICCProfile\ImageEmbedICCProfile.csproj", "{74C32226-7701-46C4-A3EE-79FBF97F5A25}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageExport", "Images\ImageExport\ImageExport.csproj", "{381E8A0C-9523-40F6-B0A1-26D7378737D1}"
@@ -334,6 +336,10 @@ Global
 		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Debug|x64.Build.0 = Debug|x64
 		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Release|x64.ActiveCfg = Release|x64
 		{16ABC796-99B8-AEC6-947E-3355E8E6B090}.Release|x64.Build.0 = Release|x64
+		{7B383C18-C183-4549-A5BF-CC488A08DF52}.Debug|x64.ActiveCfg = Debug|x64
+		{7B383C18-C183-4549-A5BF-CC488A08DF52}.Debug|x64.Build.0 = Debug|x64
+		{7B383C18-C183-4549-A5BF-CC488A08DF52}.Release|x64.ActiveCfg = Release|x64
+		{7B383C18-C183-4549-A5BF-CC488A08DF52}.Release|x64.Build.0 = Release|x64
 		{74C32226-7701-46C4-A3EE-79FBF97F5A25}.Debug|x64.ActiveCfg = Debug|x64
 		{74C32226-7701-46C4-A3EE-79FBF97F5A25}.Debug|x64.Build.0 = Debug|x64
 		{74C32226-7701-46C4-A3EE-79FBF97F5A25}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
To demonstrate generating an OutputPreview image from a PDF page, this is typically used during Soft Proofing prior to final print.