### PR TITLE
Remove OptimizeForInteractive flag.

### DIFF
--- a/Display/DotNETViewerComponent/DotNETPrintController.cs
+++ b/Display/DotNETViewerComponent/DotNETPrintController.cs
@@ -153,9 +153,7 @@ namespace DotNETViewerComponent
 
                     drawParams.UpdateRect = updateRect;
                     drawParams.SmoothFlags = SmoothFlags.Image | SmoothFlags.LineArt | SmoothFlags.Text;
-                    // If we use 'DrawFlags.OptimizeForInteractive' here, we also have to set the same
-                    // flag in the 'ImageArray2DManager.cs', function 'PageCache::Create(...)'.
-                    drawParams.Flags = DrawFlags.UseAnnotFaces | DrawFlags.OptimizeForInteractive;
+                    drawParams.Flags = DrawFlags.UseAnnotFacese;
 
 #if DRAWWITHBITMAPS
                     drawParams.Matrix = matrix;

--- a/Display/DotNETViewerComponent/ImageArray2DManager.cs
+++ b/Display/DotNETViewerComponent/ImageArray2DManager.cs
@@ -58,10 +58,8 @@ namespace DotNETViewerComponent
                 return new Tile();
             }
             DrawParams drawParams = new DrawParams();
-            // If we use 'DrawFlags.OptimizeForInteractive' here, we also have
-            // to set the same flag in the 'DotNETPrintController.cs', function
-            // 'DotNETPrintController::printDocument_PrintPage'.
-            drawParams.Flags = DrawFlags.UseAnnotFaces | DrawFlags.DoLazyErase | DrawFlags.OptimizeForInteractive;
+
+            drawParams.Flags = DrawFlags.UseAnnotFaces | DrawFlags.DoLazyErase;
             drawParams.SmoothFlags = SmoothFlags.LineArt | SmoothFlags.Text | SmoothFlags.Image;
             drawParams.BypassCopyPerm = false;
             drawParams.OptionalContentContext = occ;


### PR DESCRIPTION
This was added to PDFL a while back when there were performance issues but was never fully supported and is known to cause problems.

Since v18 of PDFL performance is very much improved so the original reason for adding this flag is not really relevant anymore.