### PR TITLE
Fix render flag setting.

### DIFF
--- a/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -11,7 +11,7 @@ using Datalogics.PDFL;
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
  * 
- * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2024, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -52,6 +52,7 @@ namespace GetSeparatedImages
                 }
 
                 PageImageParams pip = new PageImageParams();
+                pip.PageDrawFlags = DrawFlags.UseAnnotFaces;
                 pip.HorizontalResolution = 300;
                 pip.VerticalResolution = 300;
 

--- a/Images/OutputPreview/OutputPreview.cs
+++ b/Images/OutputPreview/OutputPreview.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
  * This sample demonstrates creating an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
  *
  * 
- * Copyright (c)2023, Datalogics, Inc. All rights reserved.
+ * Copyright (c)2023-2024, Datalogics, Inc. All rights reserved.
  *
  */
 
@@ -75,6 +75,7 @@ namespace OutputPreview
                         }
 
                         PageImageParams pip = new PageImageParams();
+                        pip.PageDrawFlags = DrawFlags.UseAnnotFaces;
                         pip.HorizontalResolution = 300;
                         pip.VerticalResolution = 300;
 


### PR DESCRIPTION
Because Spot Colorants may only be part of Annotation appearances, to do a proper DeviceN rendering of all colorants this needs to be set. Otherwise we collect all the spot colorants including those of Annotation appearances and setup our DeviceN rendering with it....but at the same time we tell PDFL with our render flags "don't consider them", leading to scrambled output.