### PR TITLE
SF46895 - Limit char quad matching.

### DIFF
--- a/Display/DotNETViewerComponent/DotNETView.cs
+++ b/Display/DotNETViewerComponent/DotNETView.cs
@@ -906,33 +906,36 @@ namespace DotNETViewerComponent
                     bool letter = false;
                     Quad q = null;
                     IList<Quad> charQuads = word.CharQuads;
-                    for (int i = 0; i < text.Length; ++i)
+                    if (charQuads.Count == text.Length)
                     {
-                        if (char.IsLetter(text, i) != letter)
+                        for (int i = 0; i < text.Length; ++i)
                         {
-                            if (q != null) quads.Add(q);
-                            q = null;
-                            letter = !letter;
-                        }
-                        if (q == null)
-                        {
-                            q = Utils.Clone(charQuads[i]);
-                        }
-                        else // check distance between quads - if we can concat them or not
-                        {
-                            const double interval = 0.5;
-                            if (q.BottomRight.H + interval < charQuads[i].BottomLeft.H)
+                            if (char.IsLetter(text, i) != letter)
                             {
-                                quads.Add(q);
+                                if (q != null) quads.Add(q);
+                                q = null;
+                                letter = !letter;
+                            }
+                            if (q == null)
+                            {
                                 q = Utils.Clone(charQuads[i]);
                             }
-                            else
+                            else // check distance between quads - if we can concat them or not
                             {
-                                q = Concat(q, charQuads[i]);
+                                const double interval = 0.5;
+                                if (q.BottomRight.H + interval < charQuads[i].BottomLeft.H)
+                                {
+                                    quads.Add(q);
+                                    q = Utils.Clone(charQuads[i]);
+                                }
+                                else
+                                {
+                                    q = Concat(q, charQuads[i]);
+                                }
                             }
                         }
                     }
-                    if (q != null) quads.Add(q);
+                        if (q != null) quads.Add(q);
                 }
             }
             if (quads.Count > 0) return quads;


### PR DESCRIPTION
QA noticed for a particular document viewing it caused an out of bounds exception.

This is a legacy viewer sample which had a lot of things crammed into it.  In this case text highlighting isn't quite handling unicode correctly but we have dedicated Text samples for showing how to work with the WordFinder so let's just make sure the text size and # of quads match up to prevent this problem from happening.