### PR TITLE
APDFL-6635: Add barebones Jenkinsfile to verify the .NET Framework CI agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+    agent { label 'windows-dotnet-framework-samples' }
+    options {
+        disableConcurrentBuilds()
+        timeout(time: 1, unit: 'HOURS')
+    }
+    stages {
+        stage('Verify agent') {
+            steps {
+                echo "Running .NET Framework samples CI on ${NODE_NAME}"
+                bat 'msbuild -version'
+                bat 'nuget help | findstr /B /C:"NuGet Version:"'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a minimal Jenkinsfile so repo's `develop-21` branch gets picked up by Jenkins and can validate the new CI agent before the full samples CI lands.

Fullfills **JIRA issue** [APDFL-6635](https://datalogics-jira.atlassian.net/browse/APDFL-6635)

[APDFL-6635]: https://datalogics-jira.atlassian.net/browse/APDFL-6635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ