### PR TITLE
Set develop-21 nightly cron to a fixed 05:30 start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,7 @@ pipeline {
     }
     agent none
     triggers {
-        // .NET Framework samples are Windows-only. Run after the nuget-builder
-        // nightly (~05:00, ~20 min) has uploaded packages to the raid.
-        cron(env.BRANCH_NAME == "develop-21" ? 'H(0-30) 8 * * *' : '')
+        cron(env.BRANCH_NAME == "develop-21" ? '30 5 * * *' : '')
     }
     stages {
         stage('Matrix stage') {


### PR DESCRIPTION
- change the develop-21 cron from 'H(0-30) 8 * * *' to a fixed '30 5 * * *'
- remove the stale comment referencing the old nuget-builder ~05:00 timing

part of staggering the nightly sample builds so they run one at a time after nuget-builder (03:30) uploads packages. the 05:30 start keeps this job comfortably after nuget-builder finishes.