### PR TITLE
Isolate the NuGet cache per job in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,14 @@
 @Library('jenkins-shared-libraries') _
 def ENV_LOC=[:]
+
+// Per-job NuGet cache root, so concurrent jobs on a node don't contend for
+// the shared per-user cache. Rooted at the drive root (like setConanHome)
+// to keep restored package paths under the Windows long-path limit.
+def setNugetRoot() {
+    def jobDirectory = "DL\\" + env.JOB_NAME.tokenize('/')[-2] + "_" + env.JOB_BASE_NAME
+    return getWindowsRootDrive() + jobDirectory + "\\.nuget"
+}
+
 pipeline {
     parameters {
         choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-framework-samples'], description: 'Run on specific platform')
@@ -36,6 +45,12 @@ pipeline {
                 }
                 environment {
                     APDFL_KEY = credentials('apdfl-rlm-key')
+                    // NuGet honors these for restore, msbuild, and
+                    // 'nuget locals all -clear' alike.
+                    NUGET_ROOT = setNugetRoot()
+                    NUGET_PACKAGES = "${NUGET_ROOT}\\packages"
+                    NUGET_HTTP_CACHE_PATH = "${NUGET_ROOT}\\http-cache"
+                    NUGET_PLUGINS_CACHE_PATH = "${NUGET_ROOT}\\plugins-cache"
                 }
                 stages {
                     stage('Axis'){
@@ -51,7 +66,10 @@ pipeline {
                         }
                         steps {
                             echo "Clean ${NODE}"
+                            // The NuGet cache root lives outside the workspace,
+                            // so git clean can't remove it.
                             bat """
+                                  if exist "%NUGET_ROOT%" rmdir /s /q "%NUGET_ROOT%"
                                   git rm -q -r .
                                   git reset --hard HEAD
                                   git clean -fdx

--- a/tasks.py
+++ b/tasks.py
@@ -148,9 +148,11 @@ def _copy_packages_locally(packages):
 
 def _sample_input(filename):
     """Resolve a SampleInput resource (e.g. ducky.pdf) from the restored
-    Adobe.PDF.Library.SampleInput package in the NuGet global cache."""
-    cache = os.path.join(os.path.expanduser('~'), '.nuget', 'packages',
-                         'adobe.pdf.library.sampleinput')
+    Adobe.PDF.Library.SampleInput package in the NuGet global cache.
+    NUGET_PACKAGES relocates the cache (CI isolates it per job)."""
+    cache = os.environ.get('NUGET_PACKAGES') or os.path.join(
+        os.path.expanduser('~'), '.nuget', 'packages')
+    cache = os.path.join(cache, 'adobe.pdf.library.sampleinput')
     matches = glob.glob(os.path.join(cache, '*', 'build', 'Resources',
                                      'Sample_Input', filename))
     return matches[0] if matches else filename


### PR DESCRIPTION
## Summary
- Point `NUGET_PACKAGES`, `NUGET_HTTP_CACHE_PATH`, and `NUGET_PLUGINS_CACHE_PATH` at a per-job directory rooted at the drive root (same convention as `setConanHome`), so the default-on "Clean Nuget Cache" stage clears only this job's cache instead of the node-wide user cache, and restored package paths stay under the Windows long-path limit.
- Remove the per-job cache root during `CLEAN_WORKSPACE` cleans, since it lives outside the workspace where `git clean` can't reach it.
- Resolve SampleInput resources from the relocated cache in `tasks.py`, falling back to the default per-user cache for local runs.

## Testing
- PR CI build will run with the base-branch Jenkinsfile; a Jenkins Replay with the updated Jenkinsfile is needed to exercise the new environment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)